### PR TITLE
Fix/withdrawal bugs

### DIFF
--- a/app/bridge/layout.tsx
+++ b/app/bridge/layout.tsx
@@ -1,5 +1,3 @@
-import { use } from "react";
-
 import { BridgeProvider, TrnTokenProvider, XrplCurrencyProvider } from "@/libs/context";
 import { fetchTrnTokens, getXrplCurrencies } from "@/libs/utils";
 

--- a/app/bridge/layout.tsx
+++ b/app/bridge/layout.tsx
@@ -1,18 +1,20 @@
 
 import { BridgeProvider, TrnTokenProvider, XrplCurrencyProvider } from "@/libs/context";
-import { getXrplCurrencies } from "@/libs/utils";
+import { fetchTrnTokens, getXrplCurrencies } from "@/libs/utils";
+import { use } from "react";
 
-export default function PageLayout({
+
+export default async function PageLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
 
-
+	const trnTokens = await fetchTrnTokens();
 
 	return (
-		// <TrnTokenProvider trnTokens={trnTokens}>
-		<TrnTokenProvider >
+		<TrnTokenProvider trnTokens={trnTokens}>
+		{/* <TrnTokenProvider > */}
 			<XrplCurrencyProvider currencies={getXrplCurrencies("bridge")}>
 				<BridgeProvider>{children}</BridgeProvider>
 			</XrplCurrencyProvider>

--- a/app/bridge/layout.tsx
+++ b/app/bridge/layout.tsx
@@ -1,19 +1,17 @@
-import { BridgeProvider, TrnTokenProvider, XrplCurrencyProvider } from "@/libs/context";
-import { fetchTrnTokens, getXrplCurrencies } from "@/libs/utils";
 import { use } from "react";
 
+import { BridgeProvider, TrnTokenProvider, XrplCurrencyProvider } from "@/libs/context";
+import { fetchTrnTokens, getXrplCurrencies } from "@/libs/utils";
 
 export default async function PageLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-
 	const trnTokens = await fetchTrnTokens();
 
 	return (
 		<TrnTokenProvider trnTokens={trnTokens}>
-		{/* <TrnTokenProvider > */}
 			<XrplCurrencyProvider currencies={getXrplCurrencies("bridge")}>
 				<BridgeProvider>{children}</BridgeProvider>
 			</XrplCurrencyProvider>

--- a/app/pool/layout.tsx
+++ b/app/pool/layout.tsx
@@ -1,17 +1,18 @@
 
 import { Nav } from "@/libs/components/pool";
 import { TrnTokenProvider } from "@/libs/context";
+import { fetchTrnTokens } from "@/libs/utils";
+import { use } from "react";
 
-export default function PageLayout({
+export default async function PageLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	// const trnTokens = use(fetchTrnTokens());
+	const trnTokens = await fetchTrnTokens();
 
 	return (
-		// <TrnTokenProvider trnTokens={trnTokens}>
-		<TrnTokenProvider>
+		<TrnTokenProvider trnTokens={trnTokens}>
 			<Nav />
 			{children}
 		</TrnTokenProvider>

--- a/app/pool/layout.tsx
+++ b/app/pool/layout.tsx
@@ -1,7 +1,6 @@
 import { Nav } from "@/libs/components/pool";
 import { TrnTokenProvider } from "@/libs/context";
 import { fetchTrnTokens } from "@/libs/utils";
-import { use } from "react";
 
 export default async function PageLayout({
 	children,

--- a/app/swap/layout.tsx
+++ b/app/swap/layout.tsx
@@ -5,18 +5,19 @@ import {
 	XrplCurrencyProvider,
 	XrplSwapProvider,
 } from "@/libs/context";
-import { getXrplCurrencies } from "@/libs/utils";
+import { fetchTrnTokens, getXrplCurrencies } from "@/libs/utils";
+import { use } from "react";
 
-export default function PageLayout({
+export default async function PageLayout({
 	children,
 }: Readonly<{
 	children: React.ReactNode;
 }>) {
-	// const trnTokens = use(fetchTrnTokens());
+	const trnTokens = await fetchTrnTokens();
 
 	return (
-		// <TrnTokenProvider trnTokens={trnTokens}>
-		<TrnTokenProvider>
+		<TrnTokenProvider trnTokens={trnTokens}>
+		{/* <TrnTokenProvider> */}
 			<TrnSwapProvider>
 				<XrplCurrencyProvider currencies={getXrplCurrencies("swap")}>
 					<XrplSwapProvider>{children}</XrplSwapProvider>

--- a/app/swap/layout.tsx
+++ b/app/swap/layout.tsx
@@ -5,7 +5,6 @@ import {
 	XrplSwapProvider,
 } from "@/libs/context";
 import { fetchTrnTokens, getXrplCurrencies } from "@/libs/utils";
-import { use } from "react";
 
 export default async function PageLayout({
 	children,
@@ -16,7 +15,6 @@ export default async function PageLayout({
 
 	return (
 		<TrnTokenProvider trnTokens={trnTokens}>
-		{/* <TrnTokenProvider> */}
 			<TrnSwapProvider>
 				<XrplCurrencyProvider currencies={getXrplCurrencies("swap")}>
 					<XrplSwapProvider>{children}</XrplSwapProvider>

--- a/libs/hooks/useFetchTokens.ts
+++ b/libs/hooks/useFetchTokens.ts
@@ -7,7 +7,7 @@ export function useFetchTrnTokens(trnTokens?: TrnTokens) {
 		queryKey: ["tokenMetadata"], 
 		queryFn: async () => await fetchTrnTokens(),
 		// staleTime: 1000 * 60,
-		// initialData: trnTokens,
+		initialData: trnTokens,
 		// refetchInterval: 1000 * 60 * 5,
 		refetchOnWindowFocus: true,
 	})


### PR DESCRIPTION
This PR addresses the slow loading time for tokens:
- Gets the tokens on the server, and pre-renders, but uses the data as the initial data for client side queries so they can be invalidated and refetched