### PR TITLE
Trn 711 extension support single asset deposits

### DIFF
--- a/libs/components/manage/xrpl/XrplManage.tsx
+++ b/libs/components/manage/xrpl/XrplManage.tsx
@@ -9,7 +9,7 @@ import {
 	AmountInputs,
 	Box,
 	Button,
-	ConfirmModal, // ImportToken,
+	ConfirmModal,
 	InfoItem,
 	QrModal,
 	Text,
@@ -19,19 +19,12 @@ import {
 
 export function XrplManage() {
 	const props = useManageXrplPool();
-	const { openImportModal, importModalOpen } = useXrplCurrencies();
+	const { openImportModal } = useXrplCurrencies();
 
 	const heading = useMemo(() => `${upperFirst(props.action)} liquidity`, [props.action]);
 
 	return (
 		<>
-			{/* <ImportToken
-				open={props.isOpen === false && importModalOpen}
-				onClose={() => {
-					openImportModal(false);
-				}}
-			/> */}
-
 			<TokenSelect
 				open={props.isOpen !== false}
 				onTokenClick={props.onTokenClick}

--- a/libs/components/pool/AddLiquidityXrpl.tsx
+++ b/libs/components/pool/AddLiquidityXrpl.tsx
@@ -9,6 +9,7 @@ import {
 	ActionButton,
 	AmountInputs,
 	Box,
+	Button,
 	ConfirmModal,
 	ImportToken,
 	InfoItem,
@@ -53,7 +54,11 @@ export function AddLiquidityXrpl({ children }: PropsWithChildren) {
 					tag={props.tag}
 					onClose={() => props.setTag(undefined)}
 					onConfirm={props.signTransaction}
-					title={props.action === "add" ? "Confirm Added liquidity" : "Confirm Create Pair"}
+					title={
+						props.action === "add" || props.action === "addSingle"
+							? "Confirm Added liquidity"
+							: "Confirm Create Pair"
+					}
 					description=""
 					explorerUrl={props.explorerUrl}
 					error={props.error}
@@ -76,23 +81,25 @@ export function AddLiquidityXrpl({ children }: PropsWithChildren) {
 						}
 					/>
 
-					<InfoItem
-						heading={
-							<span className="flex items-center gap-2">
-								<TokenImage
-									symbol={props.yToken.ticker || normalizeCurrencyCode(props.yToken.currency)}
-								/>
-								<Text size="md" className="!text-neutral-600">
-									{props.yToken.ticker || normalizeCurrencyCode(props.yToken.currency)} deposit
-								</Text>
-							</span>
-						}
-						value={
-							props.yTokenUSD
-								? `${props.yAmount} ($${props.yTokenUSD.toLocaleString("en-US")})`
-								: props.yAmount
-						}
-					/>
+					{props.action != "addSingle" && (
+						<InfoItem
+							heading={
+								<span className="flex items-center gap-2">
+									<TokenImage
+										symbol={props.yToken.ticker || normalizeCurrencyCode(props.yToken.currency)}
+									/>
+									<Text size="md" className="!text-neutral-600">
+										{props.yToken.ticker || normalizeCurrencyCode(props.yToken.currency)} deposit
+									</Text>
+								</span>
+							}
+							value={
+								props.yTokenUSD
+									? `${props.yAmount} ($${props.yTokenUSD.toLocaleString("en-US")})`
+									: props.yAmount
+							}
+						/>
+					)}
 
 					<div className="py-2">
 						<hr className="border-neutral-600" />
@@ -100,13 +107,30 @@ export function AddLiquidityXrpl({ children }: PropsWithChildren) {
 				</ConfirmModal>
 			)}
 
-			<Box heading={props.action === "add" ? "add liquidity" : "create pair"}>
+			<Box
+				heading={
+					props.action === "add" || props.action === "addSingle" ? "add liquidity" : "create pair"
+				}
+			>
 				{children}
+
+				{props.action != "create" && (
+					<Button
+						variant={props.action === "add" ? "secondary" : "primary"}
+						size="sm"
+						onClick={() => props.toggleSingleAssetDeposit()}
+					>
+						Single Asset Deposit:{" "}
+						{props.xToken?.ticker ?? normalizeCurrencyCode(props.xToken?.currency ?? "?")} -{" "}
+						{props.yToken?.ticker ?? normalizeCurrencyCode(props.yToken?.currency ?? "?")}
+					</Button>
+				)}
 
 				<AmountInputs
 					{...{
 						plusIcon: true,
 						labels: ["Deposit", "Deposit"],
+						singleSidedDeposit: props.action === "addSingle",
 						...props,
 					}}
 				/>
@@ -178,7 +202,7 @@ export function AddLiquidityXrpl({ children }: PropsWithChildren) {
 				<ActionButton
 					disabled={props.isDisabled}
 					onClick={() => props.setTag("review")}
-					text={props.action === "add" ? "add liquidity" : "create"}
+					text={props.action === "add" || props.action === "addSingle" ? "add liquidity" : "create"}
 				/>
 			</Box>
 		</>

--- a/libs/components/shared/AmountInputs.tsx
+++ b/libs/components/shared/AmountInputs.tsx
@@ -22,6 +22,8 @@ interface AmountInputsProps {
 	xTokenError?: string;
 	yTokenError?: string;
 
+	singleSidedDeposit?: boolean;
+
 	labels: [string, string];
 	plusIcon?: boolean;
 	between?: JSX.Element;
@@ -45,6 +47,8 @@ export function AmountInputs({
 
 	xTokenError,
 	yTokenError,
+
+	singleSidedDeposit = false,
 
 	labels,
 	plusIcon,
@@ -99,47 +103,50 @@ export function AmountInputs({
 				</Button>
 			</AmountInput>
 
-			{between
-				? between
-				: plusIcon && <div className="flex h-6 items-center justify-center text-lg">+</div>}
+			{!singleSidedDeposit &&
+				(between
+					? between
+					: plusIcon && <div className="flex h-6 items-center justify-center text-lg">+</div>)}
 
-			<AmountInput
-				token={yToken}
-				amount={yAmount}
-				label={labels[1]}
-				error={yTokenError}
-				setAmount={(amount) => setAmount({ src: "y", amount })}
-				tokenBalance={yTokenBalance}
-				tokenUSD={yTokenUSD}
-			>
-				{yToken && (
-					<Button
-						variant="secondary"
-						size="sm"
-						className="text-neutral-700"
-						onClick={() => {
-							if (!yTokenBalance) return setAmount({ src: "y", amount: "" });
-
-							setAmount({
-								src: "y",
-								amount: yTokenBalance.toString(),
-							});
-						}}
-					>
-						max
-					</Button>
-				)}
-				<Button
-					chevron
-					size="sm"
-					onClick={() => setIsOpen("yToken")}
-					variant={yToken ? "secondary" : "primary"}
-					className={classNames(yToken && "text-neutral-700")}
-					icon={ySymbol ? <TokenImage symbol={ySymbol} /> : undefined}
+			{!singleSidedDeposit && (
+				<AmountInput
+					token={yToken}
+					amount={yAmount}
+					label={labels[1]}
+					error={yTokenError}
+					setAmount={(amount) => setAmount({ src: "y", amount })}
+					tokenBalance={yTokenBalance}
+					tokenUSD={yTokenUSD}
 				>
-					{ySymbol ? ySymbol : "select token"}
-				</Button>
-			</AmountInput>
+					{yToken && (
+						<Button
+							variant="secondary"
+							size="sm"
+							className="text-neutral-700"
+							onClick={() => {
+								if (!yTokenBalance) return setAmount({ src: "y", amount: "" });
+
+								setAmount({
+									src: "y",
+									amount: yTokenBalance.toString(),
+								});
+							}}
+						>
+							max
+						</Button>
+					)}
+					<Button
+						chevron
+						size="sm"
+						onClick={() => setIsOpen("yToken")}
+						variant={yToken ? "secondary" : "primary"}
+						className={classNames(yToken && "text-neutral-700")}
+						icon={ySymbol ? <TokenImage symbol={ySymbol} /> : undefined}
+					>
+						{ySymbol ? ySymbol : "select token"}
+					</Button>
+				</AmountInput>
+			)}
 		</>
 	);
 }

--- a/libs/context/XrplCurrencyContext.tsx
+++ b/libs/context/XrplCurrencyContext.tsx
@@ -101,7 +101,7 @@ export function XrplCurrencyProvider({
 
 		return currencies.map((currency) => ({
 			...currency,
-			priceInUSD: prices[currency.currency],
+			priceInUSD: prices[normalizeCurrencyCode(currency.currency)],
 		}));
 	}, [currencies, prices]);
 

--- a/libs/hooks/useXrplTokenInputs.ts
+++ b/libs/hooks/useXrplTokenInputs.ts
@@ -42,7 +42,8 @@ export function useXrplTokenInputs<T extends XrplTokenInputState>(
 				x: Balance;
 				y: Balance;
 		  }
-		| undefined
+		| undefined,
+	singleSidedDeposit: boolean = false
 ): XrplTokenInputs {
 	const pathname = usePathname();
 	const { currencies, getBalance } = useXrplCurrencies();
@@ -118,12 +119,14 @@ export function useXrplTokenInputs<T extends XrplTokenInputState>(
 	const isDisabled = useMemo(() => {
 		if (!state.xToken || !state.yToken) return true;
 
-		if (!xAmount || !yAmount) return true;
+		if (!xAmount || (!singleSidedDeposit && !yAmount)) {
+			return true;
+		}
 
 		if (xTokenError || yTokenError) return true;
 
 		return false;
-	}, [state, xAmount, yAmount, xTokenError, yTokenError]);
+	}, [state, xAmount, yAmount, xTokenError, yTokenError, singleSidedDeposit]);
 
 	const xTokenUSD = useMemo(() => {
 		if (!xAmount || !state.xToken?.priceInUSD) return;

--- a/libs/utils/xrpl.ts
+++ b/libs/utils/xrpl.ts
@@ -352,6 +352,34 @@ export function buildDepositAmmTx(
 
 	return depo as AMMDeposit;
 }
+// https://xrpl.org/docs/references/protocol/transactions/types/ammdeposit#ammdeposit-modes
+export function buildSingleAssetDepositTx(
+	walletAddress: string,
+	TokenOne: Amount,
+	TokenTwo: Amount
+): AMMDeposit {
+	const formatAmount = (token: Amount) =>
+		isIssuedCurrency(token)
+			? { currency: token.currency, issuer: token.issuer, value: token.value }
+			: token;
+
+	const depo: AMMDeposit = {
+		TransactionType: "AMMDeposit",
+		Account: walletAddress,
+		Amount: formatAmount(TokenOne),
+		Asset: isIssuedCurrency(TokenOne)
+			? { currency: TokenOne.currency, issuer: TokenOne.issuer }
+			: { currency: "XRP" },
+		Asset2: isIssuedCurrency(TokenTwo)
+			? { currency: TokenTwo.currency, issuer: TokenTwo.issuer }
+			: { currency: "XRP" },
+		Flags: 524288, // Deposit exactly the specified amount of one asset, and receive an amount of LP Tokens based on the resulting share of the pool (minus fees). 0x00080000 tfSingleAsset
+	};
+
+	console.log("building single asset tx ", depo);
+
+	return depo as AMMDeposit;
+}
 
 // https://xrpl.org/docs/references/protocol/transactions/types/ammwithdraw
 export function buildWithdrawAmmTx(


### PR DESCRIPTION
This PR introduces single asset deposits for liquidity pools.

This addresses a couple issues with the current build especially balancing the liquidity pools. If users deposit inequal asset-value into the LP's other users will be able to benefit through arbitrage. This isn't a good outcome for the LP providers and so providing the means for single asset deposits allows LP providers to balance the pools. 

Another benefit is that users without both assets are given the chance to contribute to the LP's expanding the scope of users who can contribute to the service. 

This is described through these two links.
Arbitrage: https://xrpl.org/docs/references/protocol/transactions/types/ammcreate#ammcreate
Deposit modes: https://xrpl.org/docs/references/protocol/transactions/types/ammdeposit#ammdeposit-modes