### PR TITLE
fix wallet connect

### DIFF
--- a/libs/context/WalletContext.tsx
+++ b/libs/context/WalletContext.tsx
@@ -57,7 +57,7 @@ export function WalletProvider({ children }: PropsWithChildren) {
 	}, [network, userSession, xrplAddress]);
 
 	const isConnected = useMemo(() => {
-		if (network) return isTrnConnected && !!userSession;
+		if (network === "root") return isTrnConnected && !!userSession;
 
 		return !!xrplAddress;
 	}, [network, isTrnConnected, userSession, xrplAddress]);


### PR DESCRIPTION
A bug has been introduced where the user cannot perform any operations when only logged into there xrpl wallet (and not logged into fp). This bug causes the action buttons to appear as connect wallet when the wallet is already connected.

![image](https://github.com/user-attachments/assets/10cd7428-b905-4e8a-9f5f-d9567b2b1888)

