### PR TITLE
fix: zero input amounts when field empty

### DIFF
--- a/libs/components/shared/AmountInput.tsx
+++ b/libs/components/shared/AmountInput.tsx
@@ -8,7 +8,7 @@ import { toDollarValue } from "@/libs/utils";
 import { Text } from "./";
 
 interface AmountInputProps extends PropsWithChildren {
-	onClick?: () => void;
+	onFocus?: () => void;
 	setAmount: (amount: string) => void;
 
 	token?: Token;
@@ -26,7 +26,7 @@ export function AmountInput({
 	error,
 	amount,
 	active,
-	onClick,
+	onFocus,
 	tokenUSD,
 	children,
 	setAmount,
@@ -63,7 +63,7 @@ export function AmountInput({
 						placeholder="0.0"
 						id={`amount-${label}`}
 						onChange={(e) => setAmount(e.target.value)}
-						onClick={() => onClick?.()}
+						onFocus={() => onFocus?.()}
 						className="bg-transparent text-xl font-semibold text-neutral-700 focus:outline-none"
 					/>
 					<Text

--- a/libs/components/shared/AmountInputs.tsx
+++ b/libs/components/shared/AmountInputs.tsx
@@ -78,7 +78,7 @@ export function AmountInputs({
 				error={xTokenError}
 				tokenUSD={xTokenUSD}
 				tokenBalance={xTokenBalance}
-				onClick={() => setSrc?.("x")}
+				onFocus={() => setSrc?.("x")}
 				active={src === "x" ? true : false}
 				setAmount={(amount) => setAmount({ src: "x", amount })}
 			>
@@ -131,7 +131,7 @@ export function AmountInputs({
 					error={yTokenError}
 					tokenUSD={yTokenUSD}
 					tokenBalance={yTokenBalance}
-					onClick={() => setSrc?.("y")}
+					onFocus={() => setSrc?.("y")}
 					active={src === "y" ? true : false}
 					setAmount={(amount) => setAmount({ src: "y", amount })}
 				>

--- a/libs/context/TrnSwapContext.tsx
+++ b/libs/context/TrnSwapContext.tsx
@@ -264,13 +264,13 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 		})();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
+		trnApi,
 		setXAmount,
 		setYAmount,
 		state.xToken,
 		state.yToken,
 		tokenInputs.xAmount,
 		tokenInputs.yAmount,
-		trnApi,
 		checkSufficientLiquidity,
 	]);
 
@@ -492,7 +492,14 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 
 	useEffect(() => {
 		const checkErrors = async () => {
-			if (!state.xToken || !state.yToken || !tokenInputs.xAmount) return;
+			if (!state.xToken || !state.yToken) return;
+
+			const isValid = await checkValidPool([state.xToken.assetId, state.yToken.assetId]);
+			console.log("is valid ", isValid);
+			if (!isValid) {
+				updateState({ error: "This pair is not valid yet. Choose another token to swap" });
+				return;
+			}
 
 			if (state.sufficientLiquidity === false) {
 				return updateState({ error: "This pair has insufficient liquidity for this trade" });
@@ -516,18 +523,12 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 				return;
 			}
 
-			const isValid = await checkValidPool([state.xToken.assetId, state.yToken.assetId]);
-			if (!isValid) {
-				updateState({ error: "This pair is not valid yet. Choose another token to swap" });
-				return;
-			}
-
 			updateState({ error: "" });
 		};
 		void checkErrors();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		xAmountMax,
+		state.dexTx,
 		state.xToken,
 		state.yToken,
 		state.source,
@@ -535,7 +536,7 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 		state.slippage,
 		getTokenBalance,
 		state.canPayForGas,
-		tokenInputs.xAmount,
+		state.gasToken.name,
 		state.sufficientLiquidity,
 	]);
 

--- a/libs/context/TrnSwapContext.tsx
+++ b/libs/context/TrnSwapContext.tsx
@@ -217,7 +217,7 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 				false
 			);
 
-			if (sourceBalance.eq(0)) {
+			if (sourceBalance.toNumber() === 0) {
 				setXAmount("");
 				setYAmount("");
 				updateState({
@@ -258,6 +258,7 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 					sufficientLiquidity: true,
 				});
 			} catch (e) {
+				console.warn(e);
 				checkSufficientLiquidity();
 			}
 		})();
@@ -490,7 +491,7 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 	const checkValidPool = useCheckValidPool();
 
 	useEffect(() => {
-		const x = async () => {
+		const checkErrors = async () => {
 			if (!state.xToken || !state.yToken || !tokenInputs.xAmount) return;
 
 			if (state.sufficientLiquidity === false) {
@@ -523,7 +524,7 @@ export function TrnSwapProvider({ children }: PropsWithChildren) {
 
 			updateState({ error: "" });
 		};
-		void x();
+		void checkErrors();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		xAmountMax,


### PR DESCRIPTION
A bug was found in the most recent 1.2.2 build where the input fields weren't cleared when deleting amounts. This was due to a logic error.