### PR TITLE
convert token to unit before ordering

### DIFF
--- a/libs/context/TrnTokenContext.tsx
+++ b/libs/context/TrnTokenContext.tsx
@@ -100,23 +100,15 @@ export function TrnTokenProvider({ children, trnTokens }: TrnTokenProviderProps)
 		);
 
 		tokensWithoutPricesArray.sort((a, b) => {
-			const balanceA = tokenBalances[+a.assetId]
-				? tokenBalances[+a.assetId].toUnit()
-				: new Balance(0, a.token);
-			const balanceB = tokenBalances[+b.assetId]
-				? tokenBalances[+b.assetId].toUnit()
-				: new Balance(0, b.token);
+			const balanceA = tokenBalances[+a.assetId]?.toUnit() ?? new Balance(0, a.token);
+			const balanceB = tokenBalances[+b.assetId]?.toUnit() ?? new Balance(0, b.token);
 			return balanceB.comparedTo(balanceA);
 		});
 
 		// Sort by total value (balance * price) from highest to lowest
 		tokensWithPricesArray.sort((a, b) => {
-			const balanceA = tokenBalances[+a.assetId]
-				? tokenBalances[+a.assetId].toUnit()
-				: new Balance(0, a.token);
-			const balanceB = tokenBalances[+b.assetId]
-				? tokenBalances[+b.assetId].toUnit()
-				: new Balance(0, b.token);
+			const balanceA = tokenBalances[+a.assetId]?.toUnit() ?? new Balance(0, a.token);
+			const balanceB = tokenBalances[+b.assetId]?.toUnit() ?? new Balance(0, b.token);
 
 			const valueA = balanceA.multipliedBy(a.token.priceInUSD || 0);
 			const valueB = balanceB.multipliedBy(b.token.priceInUSD || 0);

--- a/libs/context/TrnTokenContext.tsx
+++ b/libs/context/TrnTokenContext.tsx
@@ -100,15 +100,23 @@ export function TrnTokenProvider({ children, trnTokens }: TrnTokenProviderProps)
 		);
 
 		tokensWithoutPricesArray.sort((a, b) => {
-			const balanceA = tokenBalances?.[+a.assetId] || new Balance(0, a.token);
-			const balanceB = tokenBalances?.[+b.assetId] || new Balance(0, b.token);
+			const balanceA = tokenBalances[+a.assetId]
+				? tokenBalances[+a.assetId].toUnit()
+				: new Balance(0, a.token);
+			const balanceB = tokenBalances[+b.assetId]
+				? tokenBalances[+b.assetId].toUnit()
+				: new Balance(0, b.token);
 			return balanceB.comparedTo(balanceA);
 		});
 
 		// Sort by total value (balance * price) from highest to lowest
 		tokensWithPricesArray.sort((a, b) => {
-			const balanceA = tokenBalances?.[+a.assetId] || new Balance(0, a.token);
-			const balanceB = tokenBalances?.[+b.assetId] || new Balance(0, b.token);
+			const balanceA = tokenBalances[+a.assetId]
+				? tokenBalances[+a.assetId].toUnit()
+				: new Balance(0, a.token);
+			const balanceB = tokenBalances[+b.assetId]
+				? tokenBalances[+b.assetId].toUnit()
+				: new Balance(0, b.token);
 
 			const valueA = balanceA.multipliedBy(a.token.priceInUSD || 0);
 			const valueB = balanceB.multipliedBy(b.token.priceInUSD || 0);


### PR DESCRIPTION
This PR makes a fix to the previous merged PR, TRN-987, to use the unit token balance instead of the planck for ordering tokens.